### PR TITLE
json2yamlコマンドを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,16 +99,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
@@ -135,6 +169,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +241,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -241,4 +332,6 @@ name = "ya0201ctl"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde_json",
+ "serde_yaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+serde_json = "1.0.140"
+serde_yaml = "0.9.34"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,8 +17,13 @@ pub enum TopLevelCommand {
 
     #[command(name = "json2yaml")]
     Json2Yaml {
-        #[arg(help = "Input JSON content")]
-        input: String,
+        #[arg(
+            short,
+            long,
+            help = "the JSON file to convert to YAML.
+            If not provided, reads from stdin"
+        )]
+        file: Option<String>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,12 @@ pub enum TopLevelCommand {
 
     #[command(subcommand)]
     Issue(IssueCommand),
+
+    #[command(name = "json2yaml")]
+    Json2Yaml {
+        #[arg(help = "Input JSON content")]
+        input: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
-pub mod repo;
 pub mod issue;
+pub mod repo;
 
-use crate::cli::{RepoCommand, IssueCommand};
+use crate::cli::{IssueCommand, RepoCommand};
 
 pub fn handle_repo_command(cmd: RepoCommand) {
     match cmd {
@@ -15,4 +15,9 @@ pub fn handle_issue_command(cmd: IssueCommand) {
         IssueCommand::Create { title } => issue::create::run(title),
         IssueCommand::List => issue::list::run(),
     }
+}
+
+pub fn json2yaml_command(input: String) {
+    // Placeholder for JSON to YAML conversion logic
+    println!("Converting JSON to YAML: {}", input);
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod issue;
+pub mod json2yaml;
 pub mod repo;
 
 use crate::cli::{IssueCommand, RepoCommand};
@@ -17,7 +18,6 @@ pub fn handle_issue_command(cmd: IssueCommand) {
     }
 }
 
-pub fn json2yaml_command(input: String) {
-    // Placeholder for JSON to YAML conversion logic
-    println!("Converting JSON to YAML: {}", input);
+pub fn handle_json2yaml_command(file: Option<String>) {
+    json2yaml::run(file);
 }

--- a/src/commands/json2yaml.rs
+++ b/src/commands/json2yaml.rs
@@ -1,0 +1,25 @@
+use std::io::Read;
+
+pub fn run(file: Option<String>) {
+    // read the JSON content from stdin or from a file
+    let json_content = match file {
+        Some(file_path) => std::fs::read_to_string(file_path).expect("Failed to read file"),
+        None => {
+            let mut input = String::new();
+            std::io::stdin()
+                .read_to_string(&mut input)
+                .expect("Failed to read from stdin");
+            input
+        }
+    };
+
+    // parse the JSON content
+    let json_value: serde_json::Value =
+        serde_json::from_str(&json_content).expect("Failed to parse JSON content");
+
+    // convert the JSON value to YAML
+    let yaml_content = serde_yaml::to_string(&json_value).expect("Failed to convert to YAML");
+
+    // print the YAML content to stdout
+    println!("{}", yaml_content);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 
 use clap::Parser;
 use cli::{Cli, TopLevelCommand};
-use commands::{handle_issue_command, handle_repo_command};
+use commands::{handle_issue_command, handle_repo_command, json2yaml_command};
 
 fn main() {
     let cli = Cli::parse();
@@ -12,5 +12,6 @@ fn main() {
     match cli.command {
         TopLevelCommand::Repo(cmd) => handle_repo_command(cmd),
         TopLevelCommand::Issue(cmd) => handle_issue_command(cmd),
+        TopLevelCommand::Json2Yaml { input } => json2yaml_command(input),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 
 use clap::Parser;
 use cli::{Cli, TopLevelCommand};
-use commands::{handle_issue_command, handle_repo_command, json2yaml_command};
+use commands::{handle_issue_command, handle_json2yaml_command, handle_repo_command};
 
 fn main() {
     let cli = Cli::parse();
@@ -12,6 +12,6 @@ fn main() {
     match cli.command {
         TopLevelCommand::Repo(cmd) => handle_repo_command(cmd),
         TopLevelCommand::Issue(cmd) => handle_issue_command(cmd),
-        TopLevelCommand::Json2Yaml { input } => json2yaml_command(input),
+        TopLevelCommand::Json2Yaml { file } => handle_json2yaml_command(file),
     }
 }


### PR DESCRIPTION
雑な計測だが、とりあえずpythonよりは速そう?
```
❯ time zsh -c 'for i in $(seq 500); do cat ~/mytmp/hoge.json | python3 -c "import sys, yaml, json; print(yaml.dump(json.load(sys.stdin)))" &>/dev/null; done'
zsh -c   11.44s user 3.57s system 94% cpu 15.908 total


❯ time zsh -c 'for i in $(seq 500); do ./target/release/ya0201ctl json2yaml -f ~/mytmp/hoge.json &>/dev/null; done'
zsh -c   0.04s user 0.10s system 17% cpu 0.763 total
```